### PR TITLE
fix: correct POSIX threading and linkage issues (#1)

### DIFF
--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -66,8 +66,8 @@ extern GList   *command_insert (int fd, GList *queue, const char *filename,
 extern GList   *command_remove (int fd, GList *queue, int pos, int *playing_mpeg);
 
 /* thread.c */
-extern inline void thread_lock (void);
-extern inline void thread_unlock (void);
+extern void thread_lock (void);
+extern void thread_unlock (void);
 
 /* copyright.c */
 #define		PROGRAM_DESCRIPTION "oO VTmpeg - MPEG video player daemon for Linux Oo"
@@ -76,4 +76,3 @@ extern inline void thread_unlock (void);
 extern		void show_copyright (void);
 
 #endif /* VTserver.h */
-

--- a/src/server/thread.c
+++ b/src/server/thread.c
@@ -7,21 +7,16 @@
 
 #include "VTserver.h"
 
-pthread_cond_t  cond   = PTHREAD_COND_INITIALIZER;
 pthread_mutex_t mutex  = PTHREAD_MUTEX_INITIALIZER;
 
-inline void thread_lock (void)
+void thread_lock (void)
 {
-	while (pthread_mutex_trylock (&mutex) == EBUSY)
-		pthread_cond_wait (&cond, &mutex);
-	
+	pthread_mutex_lock (&mutex);
 	return;
 }
 
-inline void thread_unlock (void)
+void thread_unlock (void)
 {
 	pthread_mutex_unlock (&mutex);
-	pthread_cond_broadcast (&cond);
-
 	return;
 }


### PR DESCRIPTION
- Refactor `thread_lock` in `src/server/thread.c` to use standard blocking `pthread_mutex_lock`. The previous implementation incorrectly invoked `pthread_cond_wait` without holding the mutex (via `trylock` failure), causing undefined behavior and potential crashes on modern NPTL systems.
- Remove `pthread_cond_t` as it is no longer required for simple mutual exclusion.
- Remove `inline` and `extern inline` qualifiers from `thread.c` and `VTserver.h` to resolve linkage ambiguities and build failures on modern compilers (C99+).