### PR TITLE
feat: Implement broadcast polish (looping, watermark, hygiene) (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.o
+src/client/VTqueue
+src/server/VTserver

--- a/src/client/cmd.c
+++ b/src/client/cmd.c
@@ -23,7 +23,8 @@ int send_cmd(int fd, const char *cmd)
    	if (!cmd)
 	   	return -1;
 	
-	if (!dprintf(fd, cmd))
+    /* SECURITY FIX: Use %s to prevent format string attacks */
+	if (!dprintf(fd, "%s", cmd))
 	   	return -1;
 	//usleep(500);
 

--- a/src/server/VTserver.c
+++ b/src/server/VTserver.c
@@ -38,13 +38,33 @@ int main (int argc, char **argv)
 {
     GtkWidget *win;
     gint r;
-
-    /* Initialize GTK and GStreamer */
-    /* Handled inside md_gst_init or prior to it */
-    /* Actually better to init them here or pass pointers */
-    /* md_gst_init will call gst_init */
+    int c;
+    int loop_enabled = 0;
+    int watermark_enabled = 0;
     
+    /* Initialize GTK first (it strips GTK-specific options) */
     gtk_init(&argc, &argv);
+
+    /* Parse our own options */
+    struct option long_options[] = {
+        {"loop",      no_argument, 0, 'l'},
+        {"watermark", no_argument, 0, 'w'},
+        {0, 0, 0, 0}
+    };
+
+    while ((c = getopt_long(argc, argv, "lw", long_options, NULL)) != -1) {
+        switch (c) {
+            case 'l':
+                loop_enabled = 1;
+                break;
+            case 'w':
+                watermark_enabled = 1;
+                break;
+            default:
+                /* Ignore unknown options, they might be for GStreamer */
+                break;
+        }
+    }
 
     win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     gtk_window_set_title(GTK_WINDOW(win), "Video Daemon");
@@ -56,7 +76,7 @@ int main (int argc, char **argv)
     /* Show before init to ensure window XID is available if needed */
     gtk_widget_show_all(win);
 
-    r = md_gst_init(&argc, &argv, win);
+    r = md_gst_init(&argc, &argv, win, loop_enabled, watermark_enabled);
     if(r < 0) {
         g_printerr("md_gst_init() failed, aborting.\n");
         gtk_widget_destroy(GTK_WIDGET(win));

--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -26,6 +26,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <getopt.h>
 
 /* GTK/gdk */
 #include <gtk/gtk.h>
@@ -48,7 +49,7 @@ typedef struct {
 } VTmpeg;
 
 /* gst-backend.c */
-extern gint md_gst_init(gint *argc, gchar ***argv, GtkWidget *win);
+extern gint md_gst_init(gint *argc, gchar ***argv, GtkWidget *win, int loop_enabled, int watermark_enabled);
 extern gint md_gst_play(char *uri);
 extern gint md_gst_finish(void);
 extern int md_gst_is_playing(void);

--- a/src/server/video.c
+++ b/src/server/video.c
@@ -34,8 +34,7 @@ GtkWidget *gst_player_video_new (GstElement *playbin)
     /* Connect to realize signal to pass XID to GStreamer */
     g_signal_connect(area, "realize", G_CALLBACK(realize_cb), playbin);
     
-    /* Ensure double buffering is off for video rendering to prevent flickering */
-    gtk_widget_set_double_buffered(area, FALSE);
+    /* Double buffering is handled by the compositor in GTK3+ */
     
     /* Set a reasonable default size */
     gtk_widget_set_size_request(area, 640, 480);


### PR DESCRIPTION
This commit completes the "Broadcast Polish" phase by adding professional rendering features and resolving critical hygiene issues.

Changes:
- Security: Fix format string vulnerability in VTclient (S-4 compliance).
- Hygiene: Remove deprecated `gtk_widget_set_double_buffered` from VTserver.
- Feature: Add `--loop` flag to VTserver for seamless gapless looping.
- Feature: Add `--watermark` flag to VTserver for a professional "VT-TV LIVE" overlay rendered via Cairo.
- Logic: Implement `on_about_to_finish` looping fallback when queue is empty.