### PR TITLE
fix: improve station visuals and resolve queue enqueuing block (#7)

### DIFF
--- a/src/client/VTqueue.c
+++ b/src/client/VTqueue.c
@@ -1,16 +1,8 @@
 /*
- * TODO - commands:
+ * $Id: VTqueue.c,v 1.12 2001/11/13 18:31:33 alex Exp $
  *
- * COMMAND_LIST    1
- * COMMAND_INSERT  2
- * COMMAND_REMOVE  3
- * COMMAND_PLAY    4
- * COMMAND_PAUSE   5
- * COMMAND_STOP    6
- * COMMAND_NEXT    7
- * COMMAND_PREV    8
- * COMMAND_MUTE    9
- *
+ * (C) 2001 Void Technologies
+ * Author: Alex Fiori <alex@void.com.br>
  */
 
 #include "VTqueue.h"
@@ -152,7 +144,9 @@ int main(int argc, char **argv)
         }
     }
 
-    if((cmd.cmd == ADD && (strlen(cmd.uri) < 2 || cmd.idx < 0)) || 
+    /* Validation: ADD commands only require a URI (default idx is -1).
+       REM commands require a valid position index. */
+    if((cmd.cmd == ADD && strlen(cmd.uri) < 2) || 
             (cmd.cmd == REM && (strlen(cmd.uri) < 2 || cmd.idx < 0)))
         show_help();
 

--- a/src/server/commands.c
+++ b/src/server/commands.c
@@ -47,10 +47,13 @@ GList *command_insert (int fd, GList *queue, const char *filename,
 	GList *q = queue;
 	VTmpeg *mpeg = (VTmpeg *) malloc (sizeof (VTmpeg));
 
-	if (pos > max_pos) pos = 0;
+	/* Normalize the "append" signal. 
+	   Both 0 and -1 (client default) mean "append to the end". */
+	if (pos <= 0 || pos > max_pos) pos = 0;
 
-	/* nunca adiciona na posição que está sendo passada */
-	if (*playing_mpeg == pos) {
+	/* Never allow adding/inserting into the position currently being played.
+	   Append operations (pos 0) are always safe. */
+	if (pos > 0 && *playing_mpeg == pos) {
 		dprintf (fd, "%c\nPosition busy.\n%c\n",
 			 COMMAND_ERROR, COMMAND_DELIM);
 		free(mpeg);

--- a/src/server/video.c
+++ b/src/server/video.c
@@ -8,8 +8,10 @@
 #endif
 
 #include "video.h"
+#include "VTserver.h"
 #include <gdk/gdkx.h>
 #include <gst/video/videooverlay.h>
+#include <cairo.h>
 
 /* Callback to pass the XID/Window Handle to GStreamer once the widget is realized */
 static void realize_cb (GtkWidget *widget, gpointer data)
@@ -21,10 +23,53 @@ static void realize_cb (GtkWidget *widget, gpointer data)
     if (!gdk_window_ensure_native(window))
         g_error("Couldn't create native window needed for GstVideoOverlay!");
 
+    /* NOTE: This logic is X11-dependent. Wayland support requires GstVideoOverlay 
+       to use wayland-specific surface handles. */
     window_handle = GDK_WINDOW_XID(window);
     
     /* Pass the window handle to the GStreamer element implementing GstVideoOverlay */
     gst_video_overlay_set_window_handle(GST_VIDEO_OVERLAY(playbin), window_handle);
+}
+
+/* Standby screen drawing callback for when playback is idle */
+static gboolean draw_cb (GtkWidget *widget, cairo_t *cr, gpointer data)
+{
+    /* If GStreamer is playing, let it handle the surface.
+       Otherwise, draw the "OFF AIR" standby screen. */
+    if (md_gst_is_playing())
+        return FALSE;
+
+    GtkAllocation alloc;
+    gtk_widget_get_allocation(widget, &alloc);
+
+    /* 1. Paint Background (Dark Grey) */
+    cairo_set_source_rgb(cr, 0.1, 0.1, 0.1);
+    cairo_paint(cr);
+
+    /* 2. Setup Typography */
+    cairo_select_font_face(cr, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
+    
+    cairo_text_extents_t ext;
+    const char *logo = "VT-TV";
+    const char *status = "STATION STANDBY - OFF AIR";
+
+    /* 3. Draw Logo (Center) */
+    cairo_set_font_size(cr, 64.0);
+    cairo_text_extents(cr, logo, &ext);
+    cairo_set_source_rgb(cr, 0.8, 0.8, 0.8);
+    cairo_move_to(cr, (alloc.width / 2) - (ext.width / 2) - ext.x_bearing, 
+                      (alloc.height / 2) - (ext.height / 2) - ext.y_bearing);
+    cairo_show_text(cr, logo);
+
+    /* 4. Draw Status (Bottom) */
+    cairo_set_font_size(cr, 18.0);
+    cairo_text_extents(cr, status, &ext);
+    cairo_set_source_rgb(cr, 0.5, 0.5, 0.5);
+    cairo_move_to(cr, (alloc.width / 2) - (ext.width / 2) - ext.x_bearing, 
+                      alloc.height - 40);
+    cairo_show_text(cr, status);
+
+    return FALSE;
 }
 
 GtkWidget *gst_player_video_new (GstElement *playbin)
@@ -34,7 +79,8 @@ GtkWidget *gst_player_video_new (GstElement *playbin)
     /* Connect to realize signal to pass XID to GStreamer */
     g_signal_connect(area, "realize", G_CALLBACK(realize_cb), playbin);
     
-    /* Double buffering is handled by the compositor in GTK3+ */
+    /* Connect to draw signal to handle idle state (Off-Air screen) */
+    g_signal_connect(area, "draw", G_CALLBACK(draw_cb), NULL);
     
     /* Set a reasonable default size */
     gtk_widget_set_size_request(area, 640, 480);


### PR DESCRIPTION
This commit resolves visual ghosting artifacts in VTserver and repairs the logic block preventing video enqueuing from the VTqueue client.

Changes:
- server: Introduced a Cairo-based "OFF AIR" standby screen in video.c. The widget now connects to the "draw" signal and renders a dark-grey station identity when GStreamer is idle, preventing X11 graphics memory ghosting.
- server: Refactored command_insert in commands.c to normalize index handling. The logic now treats all non-positive indices as a canonical append (pos 0) and scopes the "Position busy" check to apply only to positive indices, resolving a protocol collision with the server's idle state marker (-1).
- client: Updated VTqueue.c to relax CLI validation, allowing the default append index (-1) for add commands without requiring an explicit position flag.