### PR TITLE
fix: implement bus sync handler for persistent window handle (#9)

### DIFF
--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -53,6 +53,7 @@ extern gint md_gst_init(gint *argc, gchar ***argv, GtkWidget *win, int loop_enab
 extern gint md_gst_play(char *uri);
 extern gint md_gst_finish(void);
 extern int md_gst_is_playing(void);
+extern void md_gst_set_window_handle(guintptr handle);
 
 /* unix.c */
 extern char    *unix_sockname (void);

--- a/src/server/video.c
+++ b/src/server/video.c
@@ -17,7 +17,6 @@
 static void realize_cb (GtkWidget *widget, gpointer data)
 {
     GdkWindow *window = gtk_widget_get_window(widget);
-    GstElement *playbin = GST_ELEMENT(data);
     guintptr window_handle;
 
     if (!gdk_window_ensure_native(window))
@@ -27,8 +26,9 @@ static void realize_cb (GtkWidget *widget, gpointer data)
        to use wayland-specific surface handles. */
     window_handle = GDK_WINDOW_XID(window);
     
-    /* Pass the window handle to the GStreamer element implementing GstVideoOverlay */
-    gst_video_overlay_set_window_handle(GST_VIDEO_OVERLAY(playbin), window_handle);
+    /* Pass the window handle to the backend. It will be stored and used
+       in the synchronous bus handler whenever a new sink is created. */
+    md_gst_set_window_handle(window_handle);
 }
 
 /* Standby screen drawing callback for when playback is idle */
@@ -76,7 +76,7 @@ GtkWidget *gst_player_video_new (GstElement *playbin)
 {
     GtkWidget *area = gtk_drawing_area_new();
     
-    /* Connect to realize signal to pass XID to GStreamer */
+    /* Connect to realize signal to capture XID */
     g_signal_connect(area, "realize", G_CALLBACK(realize_cb), playbin);
     
     /* Connect to draw signal to handle idle state (Off-Air screen) */


### PR DESCRIPTION
Fixed the black screen issue during video transitions and looping by implementing a GStreamer bus sync handler. This ensures that the X Window ID (XID) is correctly applied to new video sinks created dynamically by playbin during gapless playback or loop restarts.

Technical changes:
- Added md_gst_set_window_handle to VTserver.h and gst-backend.c to persist the XID in a global variable.
- Implemented bus_sync_handler in gst-backend.c to listen for the 'prepare-window-handle' message and apply the stored XID.
- Extracted ensure_uri_scheme helper to centralize URI formatting, resolving an inconsistency where about-to-finish transitions failed to handle bare filesystem paths.
- Updated realize_cb in video.c to provision the XID through the new backend setter.