### PR TITLE
backend: harden initialization and refine start triggers (#15)

### DIFF
--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -8,7 +8,6 @@
 #ifndef _MAIN_H
 #define _MAIN_H 1
 
-/* leia /usr/include/features.h */
 #define _GNU_SOURCE 1
 
 #include <stdio.h>
@@ -38,44 +37,45 @@
 
 /* local */
 #include "video.h"
-
-/* informações tanto do server
-   quanto do client */
 #include "config.h"
 
 typedef struct {
-	char		filename[1024];
-	int		played;
+    char filename[1024];
+    int  played;
 } VTmpeg;
 
 /* gst-backend.c */
 extern gint md_gst_init(gint *argc, gchar ***argv, GtkWidget *win, int loop_enabled, int watermark_enabled);
 extern gint md_gst_play(char *uri);
 extern gint md_gst_finish(void);
-extern int md_gst_is_playing(void);
+extern int  md_gst_is_playing(void);
 extern void md_gst_set_window_handle(guintptr handle);
+extern gboolean md_gst_is_stopped(void);
 
 /* unix.c */
-extern char    *unix_sockname (void);
-extern int	unix_server (void);
-extern VTmpeg  *unix_getvideo (void);
-extern int      unix_get_command (void);
-extern void     unix_finish (void);
+extern char   *unix_sockname (void);
+extern int     unix_server   (void);
+extern VTmpeg *unix_getvideo (void);
+extern int     unix_get_command (void);
+extern void    unix_finish   (void);
 
 /* commands.c */
-extern void     command_list (int fd, GList *queue, int playing_mpeg);
-extern GList   *command_insert (int fd, GList *queue, const char *filename,
-				int pos, int *playing_mpeg, int max_pos);
-extern GList   *command_remove (int fd, GList *queue, int pos, int *playing_mpeg);
+extern void   command_list   (int fd, GList *queue, int playing_mpeg);
+extern GList *command_insert (int fd, GList *queue, const char *filename, int pos, int *playing_mpeg, int max_pos);
+extern GList *command_remove (int fd, GList *queue, int pos, int *playing_mpeg);
 
 /* thread.c */
-extern void thread_lock (void);
+extern void thread_lock   (void);
 extern void thread_unlock (void);
 
+/* VTserver.c helpers */
+extern void start_playback_request(void);
+
 /* copyright.c */
-#define		PROGRAM_DESCRIPTION "oO VTmpeg - MPEG video player daemon for Linux Oo"
-#define     PROGRAM_AUTHORS     "  Alexandre Fiori - <fiorix@gmail.com>\n" \
-                                "  Arnaldo Pereira - <egghunt@gmail.com>\n"
-extern		void show_copyright (void);
+#define PROGRAM_DESCRIPTION "oO VTmpeg - MPEG video player daemon for Linux Oo"
+#define PROGRAM_AUTHORS     "  Alexandre Fiori - <fiorix@gmail.com>\n" \
+                            "  Arnaldo Pereira - <egghunt@gmail.com>\n" \
+                            "  Thiago Martins  - <thiagocmc@proton.me>\n"
+extern void show_copyright (void);
 
 #endif /* VTserver.h */

--- a/src/server/commands.c
+++ b/src/server/commands.c
@@ -9,130 +9,105 @@
 
 void command_list (int fd, GList *queue, int playing_mpeg)
 {
-	int i = 0;
-	VTmpeg *mpeg;
-	char temp[128];
+    int i = 0;
+    VTmpeg *mpeg;
+    char temp[128];
 
-	if (queue == NULL) {
-		dprintf (fd, "%c\nEmpty list.\n%c\n",
-			 COMMAND_ERROR, COMMAND_DELIM);
-		return;
-	}
+    if (queue == NULL) {
+        dprintf(fd, "%c\nEmpty list.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
+        return;
+    }
 
-	memset (temp, 0, sizeof (temp));
+    memset(temp, 0, sizeof(temp));
 
-	dprintf (fd, "%c\n", COMMAND_OK);
-	dprintf (fd, "VTmpeg queue list\n");
+    dprintf(fd, "%c\n", COMMAND_OK);
+    dprintf(fd, "VTmpeg queue list\n");
 
-	while (queue != NULL) {
-		mpeg = (VTmpeg *) queue->data;
-		if (mpeg != NULL) {
-			snprintf (temp, sizeof (temp), "- playing");
+    while (queue != NULL) {
+        mpeg = (VTmpeg *) queue->data;
+        if (mpeg != NULL) {
+            snprintf(temp, sizeof(temp), "- playing");
 
-			dprintf (fd, "%d%c%s%s\n",
-				 (i + 1), COMMAND_DELIM, mpeg->filename,
-				 (playing_mpeg - 1)==i ? temp : " ");
-		}
-		
-		queue = g_list_next (queue);
-		i++;
-	}
+            dprintf(fd, "%d%c%s%s\n",
+                    (i + 1), COMMAND_DELIM, mpeg->filename,
+                    (playing_mpeg - 1)==i ? temp : " ");
+        }
 
-	dprintf (fd, "%c\n", COMMAND_DELIM);
+        queue = g_list_next(queue);
+        i++;
+    }
+
+    dprintf(fd, "%c\n", COMMAND_DELIM);
 }
 
 GList *command_insert (int fd, GList *queue, const char *filename,
-		       int pos, int *playing_mpeg, int max_pos)
+                       int pos, int *playing_mpeg, int max_pos)
 {
-	GList *q = queue;
-	VTmpeg *mpeg = (VTmpeg *) malloc (sizeof (VTmpeg));
+    GList *q = queue;
+    VTmpeg *mpeg = (VTmpeg *) malloc(sizeof(VTmpeg));
 
-	/* Normalize the "append" signal. 
-	   Both 0 and -1 (client default) mean "append to the end". */
-	if (pos <= 0 || pos > max_pos) pos = 0;
+    if (pos <= 0 || pos > max_pos) pos = 0;
 
-	/* Never allow adding/inserting into the position currently being played.
-	   Append operations (pos 0) are always safe. */
-	if (pos > 0 && *playing_mpeg == pos) {
-		dprintf (fd, "%c\nPosition busy.\n%c\n",
-			 COMMAND_ERROR, COMMAND_DELIM);
-		free(mpeg);
-		return NULL;
-	}
+    if (pos > 0 && *playing_mpeg == pos) {
+        dprintf(fd, "%c\nPosition busy.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
+        free(mpeg);
+        return NULL;
+    }
 
-	if (mpeg == NULL) {
-		dprintf (fd, "%c\nNot enough memory, server shutting down.\n%c\n",
-			 COMMAND_ERROR, COMMAND_DELIM);
-		exit (1);
-	
-	/* guarda o nome do filename */
-	} else {
-		memset (mpeg, 0, sizeof (VTmpeg));
-        /* Use snprintf instead of strncpy to ensure null termination and avoid truncation warning */
-		snprintf(mpeg->filename, sizeof(mpeg->filename), "%s", filename);
-	}
+    if (mpeg == NULL) {
+        dprintf(fd, "%c\nNot enough memory, server shutting down.\n%c\n",
+                COMMAND_ERROR, COMMAND_DELIM);
+        exit(1);
+    } else {
+        memset(mpeg, 0, sizeof(VTmpeg));
+        snprintf(mpeg->filename, sizeof(mpeg->filename), "%s", filename);
+    }
 
-#if 0
-	/* testa o mpeg, sem audio */
-	mpeg->mpeg = SMPEG_new (filename, &mpeg->info, 0);
-	if ((error = SMPEG_error (mpeg->mpeg))) {
-		dprintf (fd, "%c\n%s\n%c\n", COMMAND_ERROR, error, COMMAND_DELIM);
-		return NULL;
-	}
-#endif
+    if (!pos)
+        q = g_list_append(q, mpeg);
+    else {
+        if (*playing_mpeg > pos) *playing_mpeg += 1;
+        q = g_list_insert(q, mpeg, (pos - 1));
+    }
 
-	if (!pos)
-		q = g_list_append (q, mpeg);
-	else {
-		if (*playing_mpeg > pos) *playing_mpeg += 1;
-		q = g_list_insert (q, mpeg, (pos - 1));
-	}
+    if (q == NULL) {
+        dprintf(fd, "%c\nCannot %s on the list.\n%c\n",
+                COMMAND_ERROR, !pos ? "append" : "insert", COMMAND_DELIM);
+        /* Fix: don’t leak mpeg on list failure */
+        free(mpeg);
+        return NULL;
+    }
 
-	if (q == NULL) {
-		dprintf (fd, "%c\nCannot %s on the list.\n%c\n",
-			 COMMAND_ERROR, !pos ? "append" : "insert", COMMAND_DELIM);
-        /* If insertion fails but we allocated mpeg, we might leak it if not freed? 
-           Original code didn't handle this well, but g_list_append usually succeeds 
-           unless OOM. Keeping original logic structure but adding strict hygiene is safer. */
-		return NULL;
-	}
-
-	dprintf (fd, "%c\nFilename %s OK\n%c\n", COMMAND_OK, filename, COMMAND_DELIM);
-
-	return q;
+    dprintf(fd, "%c\nFilename %s OK\n%c\n", COMMAND_OK, filename, COMMAND_DELIM);
+    return q;
 }
 
 GList *command_remove (int fd, GList *queue, int pos, int *playing_mpeg)
 {
-	VTmpeg *mpeg;
-	GList *q = queue;
+    VTmpeg *mpeg;
+    GList *q = queue;
 
-	/* não remove o video que está tocando */
-	if (*playing_mpeg == pos) {
-		dprintf (fd, "%c\nPosition busy.\n%c\n",
-			 COMMAND_ERROR, COMMAND_DELIM);
-		return NULL;
-	} else if (!pos) {
-		invalid_position:
-		dprintf (fd, "%c\nInvalid position.\n%c\n",
-			 COMMAND_ERROR, COMMAND_DELIM);
-		return NULL;
-	}
+    if (*playing_mpeg == pos) {
+        dprintf(fd, "%c\nPosition busy.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
+        return NULL;
+    } else if (!pos) {
+invalid_position:
+        dprintf(fd, "%c\nInvalid position.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
+        return NULL;
+    }
 
-	mpeg = g_list_nth_data (q, (pos - 1));
-	if (mpeg) {
-		q = g_list_remove (q, mpeg);
-		free (mpeg);
-	} else goto invalid_position;
+    mpeg = g_list_nth_data(q, (pos - 1));
+    if (mpeg) {
+        q = g_list_remove(q, mpeg);
+        free(mpeg);
+    } else goto invalid_position;
 
-	if (q == NULL)
-		dprintf (fd, "%c\nCannot remove position %d\n%c\n",
-			 COMMAND_ERROR, pos, COMMAND_DELIM);
-	else
-		dprintf (fd, "%c\nRemove position %d OK\n%c\n",
-			 COMMAND_OK, pos, COMMAND_DELIM);
+    if (q == NULL)
+        dprintf(fd, "%c\nCannot remove position %d\n%c\n", COMMAND_ERROR, pos, COMMAND_DELIM);
+    else
+        dprintf(fd, "%c\nRemove position %d OK\n%c\n", COMMAND_OK, pos, COMMAND_DELIM);
 
-	if (*playing_mpeg > pos) *playing_mpeg -= 1;
+    if (*playing_mpeg > pos) *playing_mpeg -= 1;
 
-	return q;
+    return q;
 }


### PR DESCRIPTION
This commit provides the final hardening for the modernized GStreamer playback engine, ensuring fail-safe operations and deterministic triggers.

Key changes:
- backend: Implement fail-safe fallback in `md_gst_init`. If ghost pad creation for the custom sink bin fails, the system now correctly destroys the partial bin and falls back to legacy XID embedding.
- backend: Stabilize widget refcounting by removing manual unref of the gtksink widget, avoiding potential crashes with floating references.
- server: Refine IPC trigger logic. The system now captures the empty state of the queue BEFORE insertion to ensure a deterministic 0->1 state transition trigger for auto-start.
- server: Enforce main-thread serialization for all playback triggers.