### PR TITLE
security: fix IPC buffer overflow and client resource leak (#17)

### DIFF
--- a/src/client/VTqueue.c
+++ b/src/client/VTqueue.c
@@ -76,7 +76,7 @@ static int VT_send_command(VTCommand *cmd)
 
     //sleep(1);
     shutdown(fd, 2);
-    close(fd);
+    /* Fix: Remove double-close. fclose(fp) handles the fd. */
     fclose(fp);
 
     return 0;

--- a/src/server/unix.c
+++ b/src/server/unix.c
@@ -188,7 +188,9 @@ void unix_client (int fd)
             char filename[1024];
 
             memset(filename, 0, sizeof(filename));
-            sscanf(temp + 2, "%[^];];%d\n", filename, &pos);
+            /* SECURITY FIX: Bound read to 1023 chars to prevent stack overflow.
+               Also fixed scan set to correctly match ';'. */
+            sscanf(temp + 2, "%1023[^;];%d\n", filename, &pos);
 
             /* Deterministic start check before mutation */
             was_empty = (queue == NULL);


### PR DESCRIPTION
Fix a stack buffer overflow vulnerability in the server's IPC command handling and a resource management error in the client.

- In `src/server/unix.c`:
  - Constrain `sscanf` parsing of the `COMMAND_INSERT` payload to 1023 characters, ensuring it fits within the 1024-byte `filename` buffer.
  - Correct the scan set from `%[^];]` to `%1023[^;]`, ensuring the filename is properly delimited by the protocol separator.

- In `src/client/VTqueue.c`:
  - Remove the explicit `close(fd)` call before `fclose(fp)`. Since `fp` is created via `fdopen`, `fclose` owns the file descriptor and closing it manually violates POSIX stream semantics (double-close).

These changes prevent potential denial-of-service via malformed IPC messages and ensure robust resource teardown in the client.