### PR TITLE
unix: Harden command parsing and fix protocol docs (#19)

### DIFF
--- a/src/include/config.h
+++ b/src/include/config.h
@@ -24,12 +24,12 @@
   especificação do protocolo
 
   o client envia:
-  1. para listar o queue: list;
-  2. para inserir no queue: insert;filename;[pos]
-  3. para remover do queue: remove;pos
+  1. para listar o queue: 1
+  2. para inserir no queue: 2 [filename];[pos]
+  3. para remover do queue: 3 [pos]
 
   o server responde:
-  1. pro comando 'list':
+  1. pro comando 'list' (1):
   
      COMMAND_OK || COMMAND_ERROR
      pos - filename
@@ -41,7 +41,7 @@
      2 - /home/video/test.mpeg
      COMMAND_DELIM
 
-  2. pro comando 'insert' e 'remove':
+  2. pro comando 'insert' (2) e 'remove' (3):
 
      COMMAND_OK || COMMAND_ERROR
      COMMAND_DELIM

--- a/src/server/unix.c
+++ b/src/server/unix.c
@@ -172,10 +172,15 @@ void unix_client (int fd)
 {
     GList *q = NULL;
     char temp[2048];
+    ssize_t bytes_read;
     gboolean was_empty = FALSE;
 
     memset(temp, 0, sizeof(temp));
-    if (read(fd, temp, sizeof(temp)) < 0) return;
+    
+    /* Securely read from socket, ensuring null termination. */
+    bytes_read = read(fd, temp, sizeof(temp) - 1);
+    if (bytes_read <= 0) return;
+    temp[bytes_read] = '\0';
 
     switch (atoi(temp)) {
 


### PR DESCRIPTION
*   **src/server/unix.c**:
    *   Modified `unix_client` to check the return value of `read()`.
    *   Explicitly null-terminate the receive buffer based on the number of
        bytes read to prevent stack buffer over-reads during parsing.
    *   Added a check for `read() <= 0` (EOF/Error) to return early.

*   **src/include/config.h**:
    *   Rewrote the protocol specification comments to accurately describe
        the numeric command codes (1, 2, 3) and their argument formats,
        resolving critical documentation drift.

This change prevents potential undefined behavior when processing malformed or boundary-case client messages and ensures the protocol documentation is correct for future development.