### PR TITLE
core: Fix concurrency Use-After-Free and client portability (#21)

### DIFF
--- a/src/client/VTqueue.c
+++ b/src/client/VTqueue.c
@@ -82,6 +82,23 @@ static int VT_send_command(VTCommand *cmd)
     return 0;
 }
 
+/* 
+ * Moved from nested function in main() to file scope for C99 compliance.
+ */
+static void show_help(const char *progname) {
+    fprintf(stdout, "use: %s OPTIONS\n"
+            "NOTES  : There are a _lot_ of commands to come.\n"
+            "OPTIONS:\n"
+            "\t--add,      -a URI       Add URI to server's play queue\n"
+            "\t--remove,   -r URI       Remove URI from server's play queue\n"
+            "\t--position, -p IDX       Queue's index to remove or add the URI into\n"
+            "\t--list,     -l           list URIs on the server's queue\n"
+            "\t--debug,    -d           run de debug mode\n"
+            "\t--help,     -h           this help\n", progname);
+
+    exit(EXIT_SUCCESS);
+}
+
 int main(int argc, char **argv)
 {
     VTCommand cmd;
@@ -96,38 +113,24 @@ int main(int argc, char **argv)
         { "help",     0, 0, 'h' },
     };
 
-    void show_help() {
-        fprintf(stdout, "use: %s OPTIONS\n"
-                "NOTES  : There are a _lot_ of commands to come.\n"
-                "OPTIONS:\n"
-                "\t--add,      -a URI       Add URI to server's play queue\n"
-                "\t--remove,   -r URI       Remove URI from server's play queue\n"
-                "\t--position, -p IDX       Queue's index to remove or add the URI into\n"
-                "\t--list,     -l           list URIs on the server's queue\n"
-                "\t--debug,    -d           run de debug mode\n"
-                "\t--help,     -h           this help\n", *argv);
-
-        exit(EXIT_SUCCESS);
-    }
-
     VT_command_init(&cmd);
     while((c = getopt_long(argc, argv, opts, optl, &optind)) != -1) {
         switch(c) {
             case 'a':
                 cmd.cmd = ADD;
                 if(optarg == NULL)
-                    show_help();
+                    show_help(argv[0]);
                 snprintf(cmd.uri, sizeof(cmd.uri), "%s", optarg);
                 break;
             case 'r':
                 cmd.cmd = REM;
                 if(optarg == NULL)
-                    show_help();
+                    show_help(argv[0]);
                 snprintf(cmd.uri, sizeof(cmd.uri), "%s", optarg);
                 break;
             case 'p':
                 if(optarg == NULL)
-                    show_help();
+                    show_help(argv[0]);
                 cmd.idx = atol(optarg);
                 break;
             case 'l':
@@ -137,10 +140,10 @@ int main(int argc, char **argv)
                 debug = 1;
                 break;
             case 'h':
-                show_help();
+                show_help(argv[0]);
                 break;
             default:
-                show_help();
+                show_help(argv[0]);
         }
     }
 
@@ -148,7 +151,7 @@ int main(int argc, char **argv)
        REM commands require a valid position index. */
     if((cmd.cmd == ADD && strlen(cmd.uri) < 2) || 
             (cmd.cmd == REM && (strlen(cmd.uri) < 2 || cmd.idx < 0)))
-        show_help();
+        show_help(argv[0]);
 
     VT_send_command(&cmd);
     return EXIT_SUCCESS;

--- a/src/server/VTserver.c
+++ b/src/server/VTserver.c
@@ -25,17 +25,16 @@ static gboolean idle_start_playback(gpointer data)
 {
     (void)data;
 
-    VTmpeg *mpeg;
-
     /*
      * Robust Idle Check:
      * Only start if the pipeline is explicitly in GST_STATE_NULL.
      */
     if (md_gst_is_stopped()) {
-        mpeg = unix_getvideo();
-        if (mpeg) {
-            g_printerr("Starting playback (event-driven): %s\n", mpeg->filename);
-            md_gst_play(mpeg->filename);
+        char *filename = unix_getvideo();
+        if (filename) {
+            g_printerr("Starting playback (event-driven): %s\n", filename);
+            md_gst_play(filename);
+            g_free(filename);
         }
     }
 

--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -55,7 +55,8 @@ extern gboolean md_gst_is_stopped(void);
 /* unix.c */
 extern char   *unix_sockname (void);
 extern int     unix_server   (void);
-extern VTmpeg *unix_getvideo (void);
+/* Returns a newly allocated string that MUST be freed by the caller. */
+extern char   *unix_getvideo (void);
 extern int     unix_get_command (void);
 extern void    unix_finish   (void);
 

--- a/src/server/gst-backend.c
+++ b/src/server/gst-backend.c
@@ -139,17 +139,18 @@ static void on_about_to_finish(GstElement *playbin_local, gpointer data)
 {
     (void)playbin_local; (void)data;
 
-    VTmpeg *mpeg;
+    char *next_filename = NULL;
     char *new_uri = NULL;
 
     /*
      * SINGLE AUTHORITY for queue advancement.
      * This runs in the streaming thread. No GTK calls allowed.
      */
-    mpeg = unix_getvideo();
-    if (mpeg) {
-        g_printerr("Gapless transition to: %s\n", mpeg->filename);
-        new_uri = ensure_uri_scheme(mpeg->filename);
+    next_filename = unix_getvideo();
+    if (next_filename) {
+        g_printerr("Gapless transition to: %s\n", next_filename);
+        new_uri = ensure_uri_scheme(next_filename);
+        g_free(next_filename);
     } else if (g_loop_enabled && g_current_uri) {
         g_printerr("Queue empty, looping: %s\n", g_current_uri);
         new_uri = g_strdup(g_current_uri);

--- a/src/server/unix.c
+++ b/src/server/unix.c
@@ -67,10 +67,11 @@ int unix_server (void)
     return 1;
 }
 
-VTmpeg *unix_getvideo (void)
+char *unix_getvideo (void)
 {
     VTmpeg *mpeg;
     GList *q;
+    char *filename_copy = NULL;
 
     thread_lock();
 
@@ -109,10 +110,17 @@ VTmpeg *unix_getvideo (void)
         return NULL;
     }
 
+    /* 
+     * SAFE COPY: We must duplicate the string while holding the lock.
+     * Returning the 'mpeg' pointer is unsafe because the node could be
+     * freed by the IPC thread immediately after we unlock.
+     */
+    filename_copy = g_strdup(mpeg->filename);
+
     playing_mpeg++;
 
     thread_unlock();
-    return mpeg;
+    return filename_copy;
 }
 
 int unix_get_command (void)


### PR DESCRIPTION
This change resolves two critical stability and portability issues in the codebase:

1. Use-After-Free in Video Queue (Server):
   - Refactored `unix_getvideo()` to return a dynamically allocated copy (`g_strdup`) of the video filename instead of a raw pointer to internal shared memory.
   - Updated the GStreamer backend (`on_about_to_finish`) and the main event loop (`idle_start_playback`) to explicitly own and free these strings.
   - This prevents a race condition where the IPC thread could remove and free a queue item while the playback thread was reading it, causing a segmentation fault.

2. C99 Portability Violation (Client):
   - Extracted the `show_help()` function from inside `main()` to the file scope in `src/client/VTqueue.c`.
   - Nested functions are a GCC extension and are not valid C99, causing build failures on strictly compliant compilers.