### PR TITLE
fix: resolve ipc timeouts and concurrency race (#27)

### DIFF
--- a/src/client/cmd.c
+++ b/src/client/cmd.c
@@ -19,6 +19,7 @@ int send_cmd(int fd, const char *cmd)
    	fd_set fds;
    	char buf[2];
 	struct timeval tv;
+	int ret;
 	
    	if (!cmd)
 	   	return -1;
@@ -33,13 +34,18 @@ int send_cmd(int fd, const char *cmd)
 	tv.tv_sec = 1;
 	tv.tv_usec = 0;
 
-	if (select(fd + 1, &fds, NULL, NULL, &tv)) {
+	/* Fix: Explicitly check for success (>0) to handle timeouts correctly */
+	ret = select(fd + 1, &fds, NULL, NULL, &tv);
+	if (ret > 0) {
 		memset(buf, 0, sizeof(buf));
 		if (!read(fd, buf, sizeof(buf)))
 	   		return -1;
 
 		if (*buf == COMMAND_ERROR)
 	   		return 0;
+	} else {
+		/* Timeout (0) or Error (-1) */
+		return -1;
 	}
    
 	return 1;
@@ -54,6 +60,7 @@ char *get_cmd_result(FILE *fp)
    	fd_set fds;
    	int fd;
 	struct timeval tv;
+	int ret;
 	
 	fd = fileno(fp);
 	
@@ -62,14 +69,19 @@ char *get_cmd_result(FILE *fp)
 	tv.tv_sec = 1;
 	tv.tv_usec = 0;
 
-	if (select(fd + 1, &fds, NULL, NULL, &tv)) {
+	/* Fix: Explicitly check for success (>0) to prevent infinite loops on timeout */
+	ret = select(fd + 1, &fds, NULL, NULL, &tv);
+	if (ret > 0) {
 		memset(result_buf, 0, MAX_RESULT_LINE_LEN);	
 		if (!fgets(result_buf, MAX_RESULT_LINE_LEN, fp))
 	   		return NULL;
 
 		if (*result_buf == COMMAND_DELIM)
 	   		return NULL;
+
+		return result_buf;
 	}
 		
-	return result_buf;
+	/* Timeout (0) or Error (-1) returns NULL to break the client loop */
+	return NULL;
 }


### PR DESCRIPTION
* fix(client): handle select() timeouts safely Explicitly check the return value of `select` in `send_cmd` and `get_cmd_result`. Previously, a timeout (return 0) fell through to logic assuming success, causing `VTqueue` to enter an infinite loop printing stale buffers if the server was unresponsive. The functions now return explicit error codes (-1 or NULL) on timeout, ensuring the client terminates gracefully.

* fix(server): eliminate data race on `g_current_uri` Expand the critical section in `on_about_to_finish` to enclose the read and log of `g_current_uri`. Previously, this pointer was accessed without the mutex lock, creating a race condition where the main thread could free the pointer while the streaming thread was attempting to print it, leading to potential use-after-free crashes.