### PR TITLE
hygiene: fix UB, memory leaks and silent IPC errors (#33)

### DIFF
--- a/src/client/VTqueue.c
+++ b/src/client/VTqueue.c
@@ -113,6 +113,7 @@ int main(int argc, char **argv)
         { "list",     0, 0, 'l' },
         { "debug",    0, 0, 'd' },
         { "help",     0, 0, 'h' },
+        { 0, 0, 0, 0 }
     };
 
     VT_command_init(&cmd);

--- a/src/client/cmd.c
+++ b/src/client/cmd.c
@@ -40,7 +40,7 @@ int send_cmd(int fd, const char *cmd)
 	ret = select(fd + 1, &fds, NULL, NULL, &tv);
 	if (ret > 0) {
 		memset(buf, 0, sizeof(buf));
-		if (!read(fd, buf, sizeof(buf)))
+		if (read(fd, buf, sizeof(buf)) <= 0)
 	   		return -1;
 
 		if (*buf == COMMAND_ERROR)

--- a/src/server/gst-backend.c
+++ b/src/server/gst-backend.c
@@ -384,6 +384,11 @@ gint md_gst_init(gint *argc, gchar ***argv, GtkWidget *win, int loop_enabled, in
         } else {
             g_printerr("Failed to create bin elements, falling back.\n");
             if (sink_bin) gst_object_unref(GST_OBJECT(sink_bin));
+            if (convert) gst_object_unref(GST_OBJECT(convert));
+            if (scale) gst_object_unref(GST_OBJECT(scale));
+            if (overlay) gst_object_unref(GST_OBJECT(overlay));
+            /* sink was not added to bin, so it is floating/owned by us */
+            if (sink) gst_object_unref(GST_OBJECT(sink));
         }
     }
 


### PR DESCRIPTION
Fixes three critical hygiene violations:
- Adds the mandatory null-terminator to the `optl` array in `VTqueue.c` to prevent undefined behavior during argument parsing.
- Updates `send_cmd` in `cmd.c` to explicitly handle negative return values from `read()`, ensuring socket errors are reported rather than masked.
- Adds explicit resource cleanup in `gst-backend.c` to free floating GStreamer elements (convert, scale, overlay, sink) when bin initialization fails, preventing memory leaks on the fallback path.