### PR TITLE
ipc: harden input validation and uri encoding (#37)

### DIFF
--- a/src/server/gst-backend.c
+++ b/src/server/gst-backend.c
@@ -33,8 +33,12 @@ static char *ensure_uri_scheme(const char *uri)
     if (strstr(uri, "://")) {
         return g_strdup(uri);
     } else {
-        /* NOTE: For best practice, consider g_filename_to_uri() later. */
-        return g_strdup_printf("file://%s", uri);
+        /* 
+         * Use GLib's utility to correctly percent-encode local paths.
+         * This handles spaces and special characters that would otherwise
+         * break the GStreamer URI parser.
+         */
+        return g_filename_to_uri(uri, NULL, NULL);
     }
 }
 


### PR DESCRIPTION
This change addresses multiple security and stability issues in the IPC pipeline between the CLI client and the video server daemon.

Technically, the client (`VTqueue`) now implements strict path canonicalization using `realpath` to ensure all file paths sent to the server are absolute, resolving issues with daemon-side resolution of relative paths. Input buffers are explicitly bounds-checked before formatting commands to prevent silent truncation.

The server (`unix.c`) now strictly parses IPC payloads, rejecting any insertion commands that do not strictly match the expected protocol format, preventing coercion of malformed data. Additionally, the GStreamer backend (`gst-backend.c`) now utilizes `g_filename_to_uri` instead of ad-hoc string formatting, ensuring that file paths with spaces or special characters are correctly percent-encoded for the media pipeline.