### PR TITLE
refactor(server): decouple IPC I/O from command logic (#43)

### DIFF
--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -64,9 +64,8 @@ extern int     unix_get_command (void);
 extern void    unix_finish   (void);
 
 /* commands.c */
-extern void   command_list   (int fd, GList *queue, int playing_mpeg);
-extern GList *command_insert (int fd, GList *queue, const char *filename, int pos, int *playing_mpeg, int max_pos);
-extern GList *command_remove (int fd, GList *queue, int pos, int *playing_mpeg);
+/* Returns a newly allocated string that MUST be freed by the caller, or NULL. */
+extern char *command_process(const char *payload, GList **queue, int *playing_mpeg, int *cmd_effect);
 
 /* thread.c */
 extern void thread_lock   (void);


### PR DESCRIPTION
Consolidate all command parsing, validation, and execution logic into a new unified `command_process` function within the `commands.c` module. This change enforces the project's architectural layering invariant (3.4), which mandates a strict separation between the IPC transport layer and the command processing layer.

The `unix.c` module is now a pure transport orchestrator, responsible only for reading from the socket, passing the raw payload to `command_process`, and writing the returned response. It no longer contains any application-level parsing logic like `atoi` or `sscanf`.

Additionally, this change introduces strict input validation (S-1) at the system boundary. The `command_process` function now verifies that all incoming file paths are absolute before they are added to the queue, preventing errors deep within the GStreamer backend and improving overall system robustness. The previous implementation incorrectly trusted client- side validation.

The new interface returns both a string response for the client and an integer side-effect code, allowing the IPC layer to signal the main application thread without needing to parse the command itself. This clean separation resolves the architectural ambiguities that caused previous refactoring attempts to fail.