### PR TITLE
server: enforce queue limit and add fifo consumption (#45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ The system is divided into two decoupled components:
 *   **`VTserver`**: The core engine. It manages a GStreamer 1.0 pipeline, renders video into a GTK 3 window, and hosts a UNIX domain socket server to process commands. It supports gapless transitions between queue items and features a "Station Standby" screen when idle.
 *   **`VTqueue`**: The control client. A POSIX-compliant CLI tool that communicates with the server to manage the playback queue (listing, adding, and removing items).
 
+### Queue Behavior
+
+The server is hardened with a **2048-item limit** to prevent memory exhaustion and ensure stability. The queue management logic depends on the `--loop` flag:
+*   **Default (Station Mode):** The queue operates as a FIFO (First-In, First-Out). Videos are removed from the queue after they are played, allowing for continuous, long-term operation without manual cleanup.
+*   **Loop Mode (`-l`, `--loop`):** The queue is treated as a persistent playlist. Videos remain in the queue after playback, and the server cycles back to the first item upon reaching the end.
+
 ## Requirements
 
 ### Build Dependencies
@@ -77,7 +83,7 @@ Communication occurs over a UNIX domain socket using a simple text-based protoco
 | Command | ID | Arguments | Server Response |
 | :--- | :--- | :--- | :--- |
 | **List** | `1` | None | `S` (OK) + Queue List + `;` |
-| **Insert** | `2` | `filename;pos` | `S` (OK) or `E` (Error) + `;` |
+| **Insert** | `2` | `filename;pos` | `S` (OK) or `E` (Error) + `;`. Can fail if queue is full. |
 | **Remove** | `3` | `pos` | `S` (OK) or `E` (Error) + `;` |
 
 *Note: The server uses the `S` (Success) and `E` (Error) characters followed by the `;` delimiter for all responses.*

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -15,6 +15,9 @@
    do servidor */
 #define MAX_RESULT_LINE_LEN 2048
 
+/* Hard limit on queue depth to prevent memory exhaustion DoS */
+#define MAX_QUEUE_LEN 2048
+
 /* definições do widget onde deverá passar o mpeg */
 #define VIDEO_WIDTH	640
 #define VIDEO_HEIGHT	480

--- a/src/server/VTserver.c
+++ b/src/server/VTserver.c
@@ -112,7 +112,7 @@ int main (int argc, char **argv)
 
     show_copyright();
 
-    if (!unix_server()) {
+    if (!unix_server(loop_enabled)) {
         fprintf(stderr, "VTmpegd: Cannot create the server.\n");
         return 0;
     }

--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -57,7 +57,7 @@ extern gboolean md_gst_is_stopped(void);
 
 /* unix.c */
 extern char   *unix_sockname (void);
-extern int     unix_server   (void);
+extern int     unix_server   (int loop_enabled);
 /* Returns a newly allocated string that MUST be freed by the caller. */
 extern char   *unix_getvideo (void);
 extern int     unix_get_command (void);

--- a/src/server/commands.c
+++ b/src/server/commands.c
@@ -51,6 +51,10 @@ static char *command_insert (GList **p_queue, const char *filename,
     VTmpeg *mpeg;
     int max_pos = g_list_length(queue) + 1;
 
+    if (g_list_length(queue) >= MAX_QUEUE_LEN) {
+        return g_strdup_printf("%c\nQueue is full (max %d items).\n%c\n", COMMAND_ERROR, MAX_QUEUE_LEN, COMMAND_DELIM);
+    }
+
     if (!g_path_is_absolute(filename)) {
         return g_strdup_printf("%c\nError: Path must be absolute.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
     }


### PR DESCRIPTION
Implement a hard limit of 2048 items for the video playback queue to prevent a denial-of-service vulnerability where a client could cause memory exhaustion.

The server's queue management is also enhanced with a new FIFO (First-In, First-Out) consumption model for non-looping playback. When the server is started in its default "station" mode (without the --loop flag), videos are now removed from the queue after being played. This allows the server to run indefinitely without requiring manual queue cleanup or restarts, as memory usage remains stable.

The existing --loop functionality is preserved, where the queue acts as a persistent, repeating playlist.

- Define MAX_QUEUE_LEN in config.h to establish the safety limit.
- Update commands.c to reject insertions when the queue is full.
- Modify unix.c to consume items from the queue in non-loop mode.
- Update README.md to reflect the new limit and behavior.