### PR TITLE
Server: Fix Loop Mode Playlist Index Wrap-Around (#47)

### DIFF
--- a/src/server/unix.c
+++ b/src/server/unix.c
@@ -96,9 +96,12 @@ char *unix_getvideo (void)
 
         int len = (int)g_list_length(queue);
         if (playing_mpeg >= len) {
-            playing_mpeg = -1; /* End of playlist, gst-backend handles restart */
-            thread_unlock();
-            return NULL;
+            /* 
+             * Wrap around to the beginning of the playlist.
+             * This ensures the next video returned is the first one,
+             * preventing the backend from repeating the last URI.
+             */
+            playing_mpeg = 0;
         }
 
         mpeg = g_list_nth_data(queue, playing_mpeg);


### PR DESCRIPTION
This change corrects a logic error in `src/server/unix.c` that caused the final video in a playlist to play twice when running in Loop Mode (`--loop`).

Previously, `unix_getvideo` returned `NULL` when the queue index reached the end of the list. This triggered a fallback mechanism in the GStreamer backend that replayed the last known URI. The updated logic now explicitly detects the end of the playlist and resets the index to 0, ensuring the next returned video is the first item in the queue. This restores the expected A->B->C->A cycling behavior.
