### PR TITLE
fix: resolve double-free in sink fallback and enable URI queues (#51)

### DIFF
--- a/src/server/commands.c
+++ b/src/server/commands.c
@@ -55,8 +55,8 @@ static char *command_insert (GList **p_queue, const char *filename,
         return g_strdup_printf("%c\nQueue is full (max %d items).\n%c\n", COMMAND_ERROR, MAX_QUEUE_LEN, COMMAND_DELIM);
     }
 
-    if (!g_path_is_absolute(filename)) {
-        return g_strdup_printf("%c\nError: Path must be absolute.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
+    if (!g_path_is_absolute(filename) && strstr(filename, "://") == NULL) {
+        return g_strdup_printf("%c\nError: Path must be absolute or a valid URI.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
     }
 
     if (pos <= 0 || pos > max_pos) pos = 0;

--- a/src/server/gst-backend.c
+++ b/src/server/gst-backend.c
@@ -298,6 +298,7 @@ static gboolean setup_modern_sink(GtkWidget *win)
 {
     GstElement *sink = NULL, *sink_bin = NULL, *convert = NULL, *scale = NULL, *overlay = NULL;
     gboolean success = FALSE;
+    gboolean elements_added = FALSE;
 
     if (!(sink = gst_element_factory_make("gtkglsink", "gtkglsink_elt")) &&
         !(sink = gst_element_factory_make("gtksink", "gtksink_elt"))) {
@@ -315,6 +316,8 @@ static gboolean setup_modern_sink(GtkWidget *win)
     }
     
     gst_bin_add_many(GST_BIN(sink_bin), convert, scale, overlay, sink, NULL);
+    elements_added = TRUE;
+    
     if (!gst_element_link_many(convert, scale, overlay, sink, NULL)) {
         g_printerr("Failed to link sink bin elements, falling back.\n");
         goto cleanup;
@@ -358,10 +361,12 @@ cleanup:
     if (success) {
         /* sink_bin now owns these, so we drop our initial ref */
     } else {
-        if (convert) gst_object_unref(GST_OBJECT(convert));
-        if (scale) gst_object_unref(GST_OBJECT(scale));
-        if (overlay) gst_object_unref(GST_OBJECT(overlay));
-        if (sink) gst_object_unref(GST_OBJECT(sink));
+        if (!elements_added) {
+            if (convert) gst_object_unref(GST_OBJECT(convert));
+            if (scale) gst_object_unref(GST_OBJECT(scale));
+            if (overlay) gst_object_unref(GST_OBJECT(overlay));
+            if (sink) gst_object_unref(GST_OBJECT(sink));
+        }
     }
     return success;
 }


### PR DESCRIPTION
- Add an `elements_added` ownership flag to `setup_modern_sink` in `src/server/gst-backend.c`. This prevents the error-cleanup path from executing manual `gst_object_unref` calls on child elements if their floating references were already transferred to the bin via `gst_bin_add_many`, resolving a critical memory corruption (double-free) during hardware-accelerated video fallback.
- Update the path validation in `command_insert` within `src/server/commands.c` to accept valid network URIs containing the `://` scheme. This replaces an overly strict local-absolute-path check, successfully unblocking the backend's inherent support for network streaming formats (e.g., HTTP, RTSP) over IPC.