### PR TITLE
server: Refactor IPC layer and add playback controls (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Use the `VTqueue` tool to control the server.
 *   **Insert at position:** `./VTqueue -a /path/to/video.mp4 -p 2`
 *   **List queue:** `./VTqueue -l`
 *   **Remove item:** `./VTqueue -r 1`
+*   **Pause Playback:** `./VTqueue --pause` (or `-P`)
+*   **Resume Playback:** `./VTqueue --resume` (or `-R`)
+*   **Stop Playback:** `./VTqueue --stop` (or `-S`)
 
 ## IPC Protocol Specification
 
@@ -106,7 +109,8 @@ Communication occurs over a UNIX domain socket using a simple text-based protoco
 │   │   ├── unix.c        # UNIX Socket server and queue management
 │   │   ├── gst-backend.c # GStreamer pipeline and gapless logic
 │   │   ├── video.c       # GTK Drawing Area and XID embedding
-│   │   └── commands.c    # Protocol command implementation
+│   │   ├── commands.c    # Protocol command implementation
+│   │   └── thread.c      # Thread management helpers
 │   └── client
 │       ├── VTqueue.c     # CLI argument parsing
 │       └── cmd.c         # Socket communication logic

--- a/src/client/VTqueue.c
+++ b/src/client/VTqueue.c
@@ -36,6 +36,15 @@ static int VT_build_command_string(VTCommand *cmd, char *buf, int size)
         case LIST:
             snprintf(buf, size, "1");
             break;
+        case PAUSE_CMD:
+            snprintf(buf, size, "%d", COMMAND_PAUSE);
+            break;
+        case STOP_CMD:
+            snprintf(buf, size, "%d", COMMAND_STOP);
+            break;
+        case RESUME_CMD:
+            snprintf(buf, size, "%d", COMMAND_PLAY); /* Re-use Play to Resume */
+            break;
     }
 
     return 0;
@@ -111,6 +120,9 @@ static void show_help(const char *progname) {
             "\t--remove,   -r IDX       Remove IDX from server's play queue\n"
             "\t--position, -p IDX       Queue's index to remove or add the URI into\n"
             "\t--list,     -l           list URIs on the server's queue\n"
+            "\t--pause,    -P           Pause playback\n"
+            "\t--resume,   -R           Resume playback\n"
+            "\t--stop,     -S           Stop playback\n"
             "\t--debug,    -d           run de debug mode\n"
             "\t--help,     -h           this help\n", progname);
 
@@ -121,12 +133,15 @@ int main(int argc, char **argv)
 {
     VTCommand cmd;
     int c, optind = 0;
-    const char *opts = "a:r:p:ldh";
+    const char *opts = "a:r:p:lPRSdh";
     const struct option optl[] = {
         { "add",      1, 0, 'a' },
         { "remove",   1, 0, 'r' },
         { "position", 1, 0, 'p' },
         { "list",     0, 0, 'l' },
+        { "pause",    0, 0, 'P' },
+        { "resume",   0, 0, 'R' },
+        { "stop",     0, 0, 'S' },
         { "debug",    0, 0, 'd' },
         { "help",     0, 0, 'h' },
         { 0, 0, 0, 0 }
@@ -179,6 +194,15 @@ int main(int argc, char **argv)
                 break;
             case 'l':
                 cmd.cmd = LIST;
+                break;
+            case 'P':
+                cmd.cmd = PAUSE_CMD;
+                break;
+            case 'S':
+                cmd.cmd = STOP_CMD;
+                break;
+            case 'R':
+                cmd.cmd = RESUME_CMD;
                 break;
             case 'd':
                 debug = 1;

--- a/src/client/VTqueue.h
+++ b/src/client/VTqueue.h
@@ -19,7 +19,10 @@
 typedef enum {
     ADD = 0,
     REM,
-    LIST
+    LIST,
+    PAUSE_CMD,
+    STOP_CMD,
+    RESUME_CMD
 } VTCommandType;
 
 typedef struct {

--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -50,6 +50,9 @@ typedef struct {
 /* gst-backend.c */
 extern gint md_gst_init(gint *argc, gchar ***argv, GtkWidget *win, int loop_enabled, int watermark_enabled);
 extern gint md_gst_play(char *uri);
+extern gint md_gst_pause(void);
+extern gint md_gst_resume(void);
+extern gint md_gst_stop(void);
 extern gint md_gst_finish(void);
 extern int  md_gst_is_playing(void);
 extern void md_gst_set_window_handle(guintptr handle);
@@ -58,14 +61,13 @@ extern gboolean md_gst_is_stopped(void);
 /* unix.c */
 extern char   *unix_sockname (void);
 extern int     unix_server   (int loop_enabled);
-/* Returns a newly allocated string that MUST be freed by the caller. */
-extern char   *unix_getvideo (void);
-extern int     unix_get_command (void);
 extern void    unix_finish   (void);
 
 /* commands.c */
-/* Returns a newly allocated string that MUST be freed by the caller, or NULL. */
-extern char *command_process(const char *payload, GList **queue, int *playing_mpeg, int *cmd_effect);
+extern void  commands_init(int loop_enabled);
+/* Returns a newly allocated string that MUST be freed by the caller. */
+extern char *command_get_next_video(void);
+extern char *command_process(const char *payload);
 
 /* thread.c */
 extern void thread_lock   (void);
@@ -73,6 +75,9 @@ extern void thread_unlock (void);
 
 /* VTserver.c helpers */
 extern void start_playback_request(void);
+extern void pause_playback_request(void);
+extern void resume_playback_request(void);
+extern void stop_playback_request(void);
 
 /* copyright.c */
 #define PROGRAM_DESCRIPTION "oO VTmpeg - MPEG video player daemon for Linux Oo"


### PR DESCRIPTION
Refactors the server architecture to strictly enforce the separation of concerns between the IPC layer (`unix.c`) and the Command layer (`commands.c`). The video queue state and logic have been moved entirely to `commands.c`.

Changes:
- Implement `commands_init` to initialize queue state.
- Move `queue` and `playing_mpeg` state from `unix.c` to `commands.c`.
- Remove dead `unix_get_command` function and unused state variables.
- Implement `md_gst_pause`, `md_gst_resume`, and `md_gst_stop` in the GStreamer backend.
- Implement `idle_pause`, `idle_resume`, and `idle_stop` callbacks in `VTserver.c` to handle IPC requests safely on the main thread.
- Update `command_process` to trigger these new callbacks.
- Add `--pause` (-P), `--resume` (-R), and `--stop` (-S) flags to the `VTqueue` client to expose these capabilities.
- Update README.md to document the new CLI flags.