### PR TITLE
feat: Implement playback status reporting and normalize enum namespace (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Use the `VTqueue` tool to control the server.
 *   **Insert at position:** `./VTqueue -a /path/to/video.mp4 -p 2`
 *   **List queue:** `./VTqueue -l`
 *   **Remove item:** `./VTqueue -r 1`
+*   **Show Playback Status:** `./VTqueue --status` (or `-s`)
 *   **Pause Playback:** `./VTqueue --pause` (or `-P`)
 *   **Resume Playback:** `./VTqueue --resume` (or `-R`)
 *   **Stop Playback:** `./VTqueue --stop` (or `-S`)
@@ -94,6 +95,7 @@ Communication occurs over a UNIX domain socket using a simple text-based protoco
 | **Next** | `7` | None | `S` (OK) or `E` (Error) + `;` |
 | **Prev** | `8` | None | `S` (OK) or `E` (Error) + `;` |
 | **Mute** | `9` | None | `S` (OK) or `E` (Error) + `;` |
+| **Status** | `10` | None | `S` (OK) + Status/Progress String + `;` |
 
 *Note: The server uses the `S` (Success) and `E` (Error) characters followed by the `;` delimiter for all responses.*
 

--- a/src/client/VTqueue.h
+++ b/src/client/VTqueue.h
@@ -17,9 +17,10 @@
 #include "config.h"
 
 typedef enum {
-    ADD = 0,
-    REM,
-    LIST,
+    ADD_CMD = 0,
+    REM_CMD,
+    LIST_CMD,
+    STATUS_CMD,
     PAUSE_CMD,
     STOP_CMD,
     RESUME_CMD

--- a/src/include/config.h
+++ b/src/include/config.h
@@ -63,5 +63,6 @@
 #define COMMAND_NEXT    7
 #define COMMAND_PREV    8
 #define COMMAND_MUTE    9
+#define COMMAND_STATUS  10
 
 #endif /* config.h */

--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -57,6 +57,9 @@ extern gint md_gst_finish(void);
 extern int  md_gst_is_playing(void);
 extern void md_gst_set_window_handle(guintptr handle);
 extern gboolean md_gst_is_stopped(void);
+extern gint64 md_gst_get_position(void);
+extern gint64 md_gst_get_duration(void);
+extern char *md_gst_get_current_uri(void);
 
 /* unix.c */
 extern char   *unix_sockname (void);

--- a/src/server/gst-backend.c
+++ b/src/server/gst-backend.c
@@ -68,6 +68,35 @@ gboolean md_gst_is_stopped(void)
     return (current == GST_STATE_NULL || current == GST_STATE_READY) ? TRUE : FALSE;
 }
 
+gint64 md_gst_get_position(void)
+{
+    gint64 pos = 0;
+    if (playbin && gst_element_query_position(playbin, GST_FORMAT_TIME, &pos)) {
+        return pos;
+    }
+    return 0;
+}
+
+gint64 md_gst_get_duration(void)
+{
+    gint64 dur = 0;
+    if (playbin && gst_element_query_duration(playbin, GST_FORMAT_TIME, &dur)) {
+        return dur;
+    }
+    return 0;
+}
+
+char *md_gst_get_current_uri(void)
+{
+    char *uri = NULL;
+    thread_lock();
+    if (g_current_uri) {
+        uri = g_strdup(g_current_uri);
+    }
+    thread_unlock();
+    return uri;
+}
+
 void md_gst_set_window_handle(guintptr handle)
 {
     g_window_handle = handle;


### PR DESCRIPTION
- Adds a new `STATUS` command (ID 10) to the IPC protocol to query active playback state and time progression.
- Implements `-s` / `--status` flag in `VTqueue` client to print a formatted time progression string (e.g., "Progress: 01:30 / 03:00").
- Extends the `gst-backend.c` media layer with thread-safe queries for `playbin` position, duration, and the current active URI.
- Normalizes `VTCommandType` in `VTqueue.h` to use a consistent `_CMD` suffix across all members (e.g., changing `ADD` to `ADD_CMD`). This resolves namespace collision risks with common C POSIX headers and aligns the module with the Principle of Least Astonishment.
- Updates documentation in `README.md` to cover the new observability flag and the expanded IPC specification.