### PR TITLE
refactor(ipc): remove dead parameter from socket init (#57)

### DIFF
--- a/src/server/VTserver.c
+++ b/src/server/VTserver.c
@@ -151,7 +151,7 @@ int main (int argc, char **argv)
     /* Initialize Command Layer state */
     commands_init(loop_enabled);
 
-    if (!unix_server(loop_enabled)) {
+    if (!unix_server()) {
         fprintf(stderr, "VTmpegd: Cannot create the server.\n");
         return 0;
     }

--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -63,7 +63,7 @@ extern char *md_gst_get_current_uri(void);
 
 /* unix.c */
 extern char   *unix_sockname (void);
-extern int     unix_server   (int loop_enabled);
+extern int     unix_server   (void);
 extern void    unix_finish   (void);
 
 /* commands.c */

--- a/src/server/unix.c
+++ b/src/server/unix.c
@@ -33,7 +33,7 @@ char *unix_sockname (void)
     return filename;
 }
 
-int unix_server (int loop_enabled)
+int unix_server (void)
 {
     int fd;
     pthread_t th;


### PR DESCRIPTION
Eliminate the unused `loop_enabled` parameter from the `unix_server` function to uphold strict logic layering principles. This refactor updates `src/server/unix.c` to simplify the socket server initialization signature, removing a remnant of previous state management that coupled the IPC layer to video playback logic. Corresponding changes are applied to the function declaration in `src/server/VTserver.h` and the call site in `src/server/VTserver.c`. This modification is purely structural and has no impact on the functionality of the `--loop` command-line flag or the engine's playback behavior.
