### PR TITLE
fix(server): clean up video queue on shutdown to prevent memory leak …

### DIFF
--- a/src/server/VTserver.c
+++ b/src/server/VTserver.c
@@ -171,6 +171,7 @@ void finish (void)
 
     unix_finish();
     unlink(unix_sockname());
+    commands_cleanup();
 
     g_printerr("Goodbye.\n");
     already_finished = 1;

--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -68,6 +68,7 @@ extern void    unix_finish   (void);
 
 /* commands.c */
 extern void  commands_init(int loop_enabled);
+extern void  commands_cleanup(void);
 /* Returns a newly allocated string that MUST be freed by the caller. */
 extern char *command_get_next_video(void);
 extern char *command_process(const char *payload);

--- a/src/server/commands.c
+++ b/src/server/commands.c
@@ -21,6 +21,18 @@ void commands_init(int loop_enabled)
     playing_mpeg = -1;
 }
 
+void commands_cleanup(void)
+{
+    if (queue) {
+        /*
+         * Correctly deallocates the list and its data.
+         * The `free` function is passed as it matches the `malloc` in command_insert.
+         */
+        g_list_free_full(queue, free);
+        queue = NULL;
+    }
+}
+
 static char *command_status(void)
 {
     char *uri = md_gst_get_current_uri();


### PR DESCRIPTION
…(#61)

The server daemon was previously leaking memory for all queued video items upon shutdown. The `VTmpeg` structs, allocated with `malloc` in `command_insert()`, were never freed from the global `queue` GList when the `finish()` function was called.

This change introduces a new `commands_cleanup()` function that uses `g_list_free_full()` to safely deallocate the entire queue, including the data within each node. This function is now called from the main `finish()` shutdown handler, ensuring all dynamically allocated queue memory is released before the process exits. This resolves the memory leak and improves the overall robustness of the server.