### PR TITLE
fix(client): correct unreliable ipc by using consistent i/o (#63)

### DIFF
--- a/src/client/VTqueue.c
+++ b/src/client/VTqueue.c
@@ -94,13 +94,18 @@ static int VT_send_command(VTCommand *cmd)
     }
 
     if(send_cmd(fd, buffer) <= 0)
-        fprintf(stderr, "error: ");
+        fprintf(stderr, "error sending command\n");
 
     if(!(fp = fdopen(fd, "r"))) {
         perror("fdopen");
         exit(1);
     }
 
+    /*
+     * This loop now correctly handles the entire server response,
+     * including error messages, because send_cmd() no longer consumes
+     * any input from the stream.
+     */
     while((p = get_cmd_result(fp)) != NULL)
         printf("%s", p);
 

--- a/src/client/cmd.c
+++ b/src/client/cmd.c
@@ -11,35 +11,29 @@
 
 static char result_buf[MAX_RESULT_LINE_LEN];
 
-/* return:
- * -1 on system error
- * 0 on error
- * 1 on success
+/*
+ * Sends a command to the server.
+ * Returns:
+ *  -1 on system/socket error
+ *   1 on success (command sent)
+ *
+ * NOTE: This function ONLY sends. All response reading must be handled
+ * by the caller using the stdio FILE* stream.
  */
 int send_cmd(int fd, const char *cmd)
 {
-   	char buf[2];
-	
    	if (!cmd)
 	   	return -1;
 	
     /* SECURITY FIX: Use %s to prevent format string attacks */
 	if (dprintf(fd, "%s", cmd) < 0)
 	   	return -1;
-	//usleep(500);
-
-    /* 
-     * Simplified receive logic:
-     * Rely on SO_RCVTIMEO set in VTqueue.c instead of manual select().
+	
+    /*
+     * The raw read() was removed to prevent mixing I/O paradigms.
+     * The caller is now responsible for reading the entire response,
+     * including status characters, via the buffered FILE* stream.
      */
-    memset(buf, 0, sizeof(buf));
-    if (read(fd, buf, sizeof(buf)) <= 0)
-        return -1;
-
-    if (*buf == COMMAND_ERROR) {
-        return 0;
-    }
-   
 	return 1;
 }
 


### PR DESCRIPTION
Refactor the client's socket communication logic to eliminate a critical bug caused by mixing raw `read()` system calls with buffered `stdio` library functions (`fdopen`, `fgets`) on the same file descriptor. This incorrect pattern leads to undefined behavior and unreliable message passing.

The `send_cmd` function in `cmd.c` has been simplified to only handle sending data to the socket. All responsibility for reading the server's response, including status codes and multi-line payloads, is now consolidated within the `VT_send_command` function in `VTqueue.c`. This ensures that a single, consistent I/O paradigm (buffered stdio) is used for all read operations on the socket stream, guaranteeing message integrity and robust client operation.