### PR TITLE
server: implement NEXT skip and MUTE toggle (#65)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 The project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-02
+
+### Added
+- **IPC:** Fully implemented `COMMAND_NEXT` (ID 7) to allow immediate skipping to the next video in the playback queue.
+- **IPC:** Fully implemented `COMMAND_MUTE` (ID 9) to toggle audio output state via the GStreamer playbin.
+- **Multimedia:** Added `md_gst_skip` and `md_gst_toggle_mute` to the backend for direct stream and property manipulation.
+
+### Changed
+- **Logic:** Decoupled `COMMAND_NEXT` from `COMMAND_PLAY` in the command layer to ensure correct queue advancement semantics.
+- **Documentation:** Updated the IPC Protocol Specification in `README.md` to reflect that all defined commands are now functional.
+
+---
+
 ## [1.0.0] - 2026-03-01
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -84,18 +84,18 @@ Use the `VTqueue` tool to control the server.
 
 Communication occurs over a UNIX domain socket using a simple text-based protocol.
 
-| Command | ID | Arguments | Server Response |
-| :--- | :--- | :--- | :--- |
-| **List** | `1` | None | `S` (OK) + Queue List + `;` |
-| **Insert** | `2` | `filename;pos` | `S` (OK) or `E` (Error) + `;`. Can fail if queue is full. |
-| **Remove** | `3` | `pos` | `S` (OK) or `E` (Error) + `;` |
-| **Play** | `4` | None | `S` (OK) or `E` (Error) + `;` |
-| **Pause** | `5` | None | `S` (OK) or `E` (Error) + `;` |
-| **Stop** | `6` | None | `S` (OK) or `E` (Error) + `;` |
-| **Next** | `7` | None | `S` (OK) or `E` (Error) + `;` |
-| **Prev** | `8` | None | `S` (OK) or `E` (Error) + `;` |
-| **Mute** | `9` | None | `S` (OK) or `E` (Error) + `;` |
-| **Status** | `10` | None | `S` (OK) + Status/Progress String + `;` |
+| Command | ID | Arguments | Server Response | Description |
+| :--- | :--- | :--- | :--- | :--- |
+| **List** | `1` | None | `S` + List + `;` | Lists the current video queue. |
+| **Insert** | `2` | `file;pos` | `S` or `E` + `;` | Inserts a video (pos 0 for end). |
+| **Remove** | `3` | `pos` | `S` or `E` + `;` | Removes the video at the given position. |
+| **Play** | `4` | None | `S` or `E` + `;` | Resumes playback. |
+| **Pause** | `5` | None | `S` or `E` + `;` | Pauses playback. |
+| **Stop** | `6` | None | `S` or `E` + `;` | Stops playback and shows standby screen. |
+| **Next** | `7` | None | `S` or `E` + `;` | Skips to the next video in the queue. |
+| **Prev** | `8` | None | `S` or `E` + `;` | Returns to the previous video in the queue. |
+| **Mute** | `9` | None | `S` or `E` + `;` | Toggles audio output on/off. |
+| **Status** | `10` | None | `S` + Info + `;` | Gets playback status and progress. |
 
 *Note: The server uses the `S` (Success) and `E` (Error) characters followed by the `;` delimiter for all responses.*
 

--- a/src/server/VTserver.c
+++ b/src/server/VTserver.c
@@ -64,6 +64,20 @@ static gboolean idle_stop_playback(gpointer data)
     return FALSE;
 }
 
+static gboolean idle_skip_playback(gpointer data)
+{
+    (void)data;
+    md_gst_skip();
+    return FALSE;
+}
+
+static gboolean idle_mute_playback(gpointer data)
+{
+    (void)data;
+    md_gst_toggle_mute();
+    return FALSE;
+}
+
 /* Public helper called from commands.c */
 void start_playback_request(void)
 {
@@ -83,6 +97,16 @@ void resume_playback_request(void)
 void stop_playback_request(void)
 {
     g_idle_add(idle_stop_playback, NULL);
+}
+
+void skip_playback_request(void)
+{
+    g_idle_add(idle_skip_playback, NULL);
+}
+
+void mute_playback_request(void)
+{
+    g_idle_add(idle_mute_playback, NULL);
 }
 
 /*

--- a/src/server/VTserver.h
+++ b/src/server/VTserver.h
@@ -53,6 +53,8 @@ extern gint md_gst_play(char *uri);
 extern gint md_gst_pause(void);
 extern gint md_gst_resume(void);
 extern gint md_gst_stop(void);
+extern gint md_gst_skip(void);
+extern gint md_gst_toggle_mute(void);
 extern gint md_gst_finish(void);
 extern int  md_gst_is_playing(void);
 extern void md_gst_set_window_handle(guintptr handle);
@@ -82,6 +84,8 @@ extern void start_playback_request(void);
 extern void pause_playback_request(void);
 extern void resume_playback_request(void);
 extern void stop_playback_request(void);
+extern void skip_playback_request(void);
+extern void mute_playback_request(void);
 
 /* copyright.c */
 #define PROGRAM_DESCRIPTION "oO VTmpeg - MPEG video player daemon for Linux Oo"

--- a/src/server/commands.c
+++ b/src/server/commands.c
@@ -261,10 +261,14 @@ char *command_process(const char *payload)
         }
 
         case COMMAND_PLAY:
-        case COMMAND_NEXT:
             /* Start or Resume playback */
             resume_playback_request();
             /* If it was empty, start_playback_request below will handle it too. */
+            break;
+            
+        case COMMAND_NEXT:
+            /* Skip forward in the queue */
+            skip_playback_request();
             break;
 
         case COMMAND_PAUSE:
@@ -284,7 +288,7 @@ char *command_process(const char *payload)
         }
 
         case COMMAND_MUTE:
-            /* Not implemented in backend yet */
+            mute_playback_request();
             break;
 
         default:

--- a/src/server/gst-backend.c
+++ b/src/server/gst-backend.c
@@ -329,6 +329,38 @@ gint md_gst_stop(void)
     return 0;
 }
 
+gint md_gst_skip(void)
+{
+    if (playbin) {
+        char *next_filename = command_get_next_video();
+        
+        /* Force pipeline reset to purge current buffers and accept new URI cleanly */
+        gst_element_set_state(playbin, GST_STATE_NULL);
+        g_atomic_int_set(&g_next_uri_scheduled, 0);
+        
+        if (next_filename) {
+            g_printerr("Skipping forward to: %s\n", next_filename);
+            md_gst_play(next_filename);
+            g_free(next_filename);
+        } else {
+            g_printerr("Skip requested, but queue is empty.\n");
+            md_gst_stop();
+        }
+    }
+    return 0;
+}
+
+gint md_gst_toggle_mute(void)
+{
+    if (playbin) {
+        gboolean current_mute = FALSE;
+        g_object_get(G_OBJECT(playbin), "mute", &current_mute, NULL);
+        g_object_set(G_OBJECT(playbin), "mute", !current_mute, NULL);
+        g_printerr("Pipeline audio %s.\n", !current_mute ? "muted" : "unmuted");
+    }
+    return 0;
+}
+
 gint md_gst_finish(void)
 {
     if (bus_watch_id > 0)


### PR DESCRIPTION
This change completes the core playback control suite by implementing the backend logic and IPC routing for the NEXT and MUTE commands.

- gst-backend.c: Added md_gst_skip() to advance the queue and reset the GStreamer pipeline for a clean stream transition. Added md_gst_toggle_mute() to toggle the playbin 'mute' property.
- commands.c: Updated the command router to map COMMAND_NEXT and COMMAND_MUTE to their functional handlers, removing previous aliases and stubs.
- VTserver.c: Implemented thread-safe idle-loop wrappers to ensure all media state mutations occur on the main thread.
- README.md / CHANGELOG: Updated documentation and bumped version to 1.1.0 to reflect protocol completion.