### PR TITLE
server: fix UNIX IPC worker shutdown lifecycle (#69)

### DIFF
--- a/src/server/VTserver.c
+++ b/src/server/VTserver.c
@@ -190,16 +190,19 @@ void finish (void)
 
     if (already_finished) {
         thread_unlock();
-        exit(EXIT_SUCCESS);
+        return;
     }
 
+    already_finished = 1;
+    thread_unlock();
+
     unix_finish();
+
+    thread_lock();
     unlink(unix_sockname());
     commands_cleanup();
 
     g_printerr("Goodbye.\n");
-    already_finished = 1;
-
     thread_unlock();
 
     md_gst_finish();

--- a/src/server/unix.c
+++ b/src/server/unix.c
@@ -9,7 +9,10 @@
 
 #include "VTserver.h"
 
-static int   server_fd;
+static int   server_fd = -1;
+static pthread_t server_th;
+static gint server_running = 0;
+static int server_thread_started = 0;
 
 static void *unix_loop   (void *arg);
 static void  unix_client (int fd);
@@ -36,7 +39,6 @@ char *unix_sockname (void)
 int unix_server (void)
 {
     int fd;
-    pthread_t th;
     struct sockaddr_un s;
 
     s.sun_family = AF_UNIX;
@@ -60,7 +62,17 @@ int unix_server (void)
     chmod(unix_sockname(), 0666);
 
     server_fd = fd;
-    pthread_create(&th, NULL, unix_loop, NULL);
+    g_atomic_int_set(&server_running, 1);
+    int err = pthread_create(&server_th, NULL, unix_loop, NULL);
+    if (err != 0) {
+        fprintf(stderr, "pthread_create: %s\n", strerror(err));
+        g_atomic_int_set(&server_running, 0);
+        close(fd);
+        server_fd = -1;
+        unlink(unix_sockname());
+        return 0;
+    }
+    server_thread_started = 1;
 
     unlink(UNIX_PATH);
     if (symlink(unix_sockname(), UNIX_PATH) < 0)
@@ -71,8 +83,16 @@ int unix_server (void)
 
 void unix_finish (void)
 {
-    shutdown(server_fd, 2);
-    close(server_fd);
+    g_atomic_int_set(&server_running, 0);
+    if (server_thread_started) {
+        pthread_join(server_th, NULL);
+        server_thread_started = 0;
+    }
+    if (server_fd >= 0) {
+        shutdown(server_fd, 2);
+        close(server_fd);
+        server_fd = -1;
+    }
     return;
 }
 
@@ -89,6 +109,7 @@ void *unix_loop (void *arg)
     fd = server_fd;
 
     for (;;) {
+        if (!g_atomic_int_get(&server_running)) break;
         FD_ZERO(&fds);
         FD_SET(fd, &fds);
         tv.tv_sec = 1; tv.tv_usec = 0;
@@ -99,6 +120,8 @@ void *unix_loop (void *arg)
          */
         int ret = select(fd + 1, &fds, NULL, NULL, &tv);
         if (ret > 0 && FD_ISSET(fd, &fds)) {
+            if (!g_atomic_int_get(&server_running)) break;
+
             /* 
              * FIX: Do not hold lock during accept() or unix_client() which calls read().
              * This prevents DoS where a client connects but doesn't send data.


### PR DESCRIPTION
Track the UNIX IPC worker thread explicitly so shutdown has a well-defined cleanup path. Store the worker pthread handle, add an atomic run flag, and retain startup state so unix_finish() joins the worker only when it was successfully created.

Initialize server_fd to -1 and reset it after cleanup so repeated teardown calls cannot operate on stdin or a stale descriptor. Validate pthread_create() using its returned error code and unwind initialized socket state on failure.

Update unix_loop() to observe the run flag before each polling cycle and again before accepting a ready connection. This prevents new IPC work from being accepted once shutdown has begun.

Restructure finish() so the global command mutex is released before unix_finish() waits for the IPC worker. Reacquire the mutex only for socket path unlinking and command cleanup, and treat duplicate shutdown calls as no-ops so the primary cleanup path can complete naturally.