### PR TITLE
server: harden IPC parsing and overlay state (#71)

### DIFF
--- a/src/include/config.h
+++ b/src/include/config.h
@@ -43,7 +43,7 @@
                                         the standby screen.
   7    NEXT                             (Server-side only)
   8    PREV                             (Server-side only)
-  9    MUTE                             (Not implemented)
+  9    MUTE                             Server-supported audio mute toggle
   10   STATUS                           Gets current playback status
                                         and progress.
 */

--- a/src/server/commands.c
+++ b/src/server/commands.c
@@ -221,6 +221,7 @@ char *command_process(const char *payload)
     int command_id = atoi(payload);
     char *response = NULL;
     gboolean was_empty = FALSE;
+    size_t payload_len = strlen(payload);
 
     /*
      * DEADLOCK FIX: COMMAND_STATUS accesses the backend state via md_gst_get_current_uri(),
@@ -243,27 +244,38 @@ char *command_process(const char *payload)
         /* COMMAND_STATUS handled above to prevent deadlock */
 
         case COMMAND_INSERT: {
-            int pos = 0;
-            int items_matched;
-            char filename[PATH_MAX];
-            char fmt[64];
+            if (payload_len > 2) {
+                int pos = 0;
+                int items_matched;
+                char filename[PATH_MAX];
+                char fmt[64];
 
-            memset(filename, 0, sizeof(filename));
-            snprintf(fmt, sizeof(fmt), "%%%zu[^;];%%d\n", sizeof(filename) - 1);
-            items_matched = sscanf(payload + 2, fmt, filename, &pos);
+                memset(filename, 0, sizeof(filename));
+                snprintf(fmt, sizeof(fmt), "%%%zu[^;];%%d\n", sizeof(filename) - 1);
+                items_matched = sscanf(payload + 2, fmt, filename, &pos);
 
-            if (items_matched != 2) {
-                response = g_strdup_printf("%c\nInvalid IPC payload for INSERT.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
+                if (items_matched != 2) {
+                    response = g_strdup_printf("%c\nInvalid IPC payload for INSERT.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
+                } else {
+                    response = command_insert(filename, pos);
+                }
             } else {
-                response = command_insert(filename, pos);
+                response = g_strdup_printf("%c\nInvalid IPC payload length.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
             }
             break;
         }
 
         case COMMAND_REMOVE: {
-            int pos = 0;
-            sscanf(payload + 2, "%d\n", &pos);
-            response = command_remove(pos);
+            if (payload_len > 2) {
+                int pos = 0;
+                if (sscanf(payload + 2, "%d\n", &pos) == 1) {
+                    response = command_remove(pos);
+                } else {
+                    response = g_strdup_printf("%c\nInvalid IPC payload format.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
+                }
+            } else {
+                response = g_strdup_printf("%c\nInvalid IPC payload length.\n%c\n", COMMAND_ERROR, COMMAND_DELIM);
+            }
             break;
         }
 

--- a/src/server/gst-backend.c
+++ b/src/server/gst-backend.c
@@ -10,7 +10,7 @@ static GtkWidget  *video_widget;
 static int g_loop_enabled = 0;
 static int g_watermark_enabled = 0;
 static char *g_current_uri = NULL;
-static guintptr g_window_handle = 0;
+static gpointer g_window_handle = NULL;
 static gboolean g_using_gtksink = FALSE;
 
 /*
@@ -99,9 +99,10 @@ char *md_gst_get_current_uri(void)
 
 void md_gst_set_window_handle(guintptr handle)
 {
-    g_window_handle = handle;
+    g_atomic_pointer_set(&g_window_handle, (gpointer)handle);
+    guintptr loaded_handle = (guintptr)g_atomic_pointer_get(&g_window_handle);
     if (playbin && GST_IS_VIDEO_OVERLAY(playbin) && !g_using_gtksink) {
-        gst_video_overlay_set_window_handle(GST_VIDEO_OVERLAY(playbin), g_window_handle);
+        gst_video_overlay_set_window_handle(GST_VIDEO_OVERLAY(playbin), loaded_handle);
     }
 }
 
@@ -114,19 +115,20 @@ static GstBusSyncReply bus_sync_handler(GstBus *bus, GstMessage *msg, gpointer d
         return GST_BUS_PASS;
 
     if (gst_is_video_overlay_prepare_window_handle_message(msg)) {
-        if (g_window_handle != 0) {
+        guintptr window_handle = (guintptr)g_atomic_pointer_get(&g_window_handle);
+        if (window_handle != 0) {
 	    GstObject *src = GST_MESSAGE_SRC(msg);
 
             /* Normal case: message source is the overlay-capable sink. */
             if (GST_IS_VIDEO_OVERLAY(src)) {
-                gst_video_overlay_set_window_handle(GST_VIDEO_OVERLAY(src), g_window_handle);
+                gst_video_overlay_set_window_handle(GST_VIDEO_OVERLAY(src), window_handle);
             } else {
                 /* Fallback: try the current playbin video-sink (some graphs emit from a bin/child). */
                 GstElement *vsink = NULL;
                 g_object_get(G_OBJECT(playbin), "video-sink", &vsink, NULL);
                 if (vsink) {
                     if (GST_IS_VIDEO_OVERLAY(vsink)) {
-                        gst_video_overlay_set_window_handle(GST_VIDEO_OVERLAY(vsink), g_window_handle);
+                        gst_video_overlay_set_window_handle(GST_VIDEO_OVERLAY(vsink), window_handle);
                     }
                     gst_object_unref(GST_OBJECT(vsink));
                 }


### PR DESCRIPTION
Validate IPC payload length before parsing INSERT and REMOVE command arguments so malformed short messages cannot advance past the command string boundary. Check REMOVE parsing results before mutating the queue, returning protocol errors for invalid payload length or format.

Store the GStreamer window handle in pointer-compatible atomic storage and use atomic get/set operations when passing it between GTK and GStreamer callback paths. Load the handle into a local snapshot before using it for overlay setup.

Update the IPC protocol documentation to describe MUTE as a server-supported audio mute toggle instead of an unimplemented command.